### PR TITLE
Add Department section to navigation and homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
         <ul>
           <li class="active"><a href="index.html">Home</a></li>
           <li><a href="#about">About</a></li>
+          <li><a href="#department">Department</a></li>
           <li><a href="#services">Services</a></li>
           <li><a href="#portfolio">Portfolio</a></li>
           <li><a href="#team">Team</a></li>
@@ -120,6 +121,54 @@
 
       </div>
     </section><!-- End About Section -->
+
+    <!-- ======= Department Section ======= -->
+    <section id="department" class="department section-bg">
+      <div class="container">
+
+        <div class="section-title">
+          <h2>Department</h2>
+          <p>Discover the teams that keep our organization moving forward every day.</p>
+        </div>
+
+        <div class="row">
+          <div class="col-lg-4 col-md-6 icon-box">
+            <div class="icon"><i class="icofont-brainstorming"></i></div>
+            <h4 class="title"><a href="">Research &amp; Development</a></h4>
+            <p class="description">Innovates with new ideas, prototypes, and cutting-edge technologies to create meaningful solutions.</p>
+          </div>
+          <div class="col-lg-4 col-md-6 icon-box mt-4 mt-md-0">
+            <div class="icon"><i class="icofont-briefcase"></i></div>
+            <h4 class="title"><a href="">Business Operations</a></h4>
+            <p class="description">Ensures seamless daily operations, resource planning, and partner relationships across the company.</p>
+          </div>
+          <div class="col-lg-4 col-md-6 icon-box mt-4 mt-lg-0">
+            <div class="icon"><i class="icofont-users-social"></i></div>
+            <h4 class="title"><a href="">People &amp; Culture</a></h4>
+            <p class="description">Supports our teams through recruitment, learning programs, and an inclusive, engaging workplace culture.</p>
+          </div>
+        </div>
+
+        <div class="row mt-4">
+          <div class="col-lg-4 col-md-6 icon-box">
+            <div class="icon"><i class="icofont-chart-histogram"></i></div>
+            <h4 class="title"><a href="">Marketing &amp; Insights</a></h4>
+            <p class="description">Crafts our brand story, builds customer journeys, and turns data into actionable growth strategies.</p>
+          </div>
+          <div class="col-lg-4 col-md-6 icon-box mt-4 mt-md-0">
+            <div class="icon"><i class="icofont-code-alt"></i></div>
+            <h4 class="title"><a href="">Engineering</a></h4>
+            <p class="description">Develops reliable platforms and digital experiences with scalable architecture and responsive support.</p>
+          </div>
+          <div class="col-lg-4 col-md-6 icon-box mt-4 mt-lg-0">
+            <div class="icon"><i class="icofont-live-support"></i></div>
+            <h4 class="title"><a href="">Customer Success</a></h4>
+            <p class="description">Partners with clients to understand their goals, provide guidance, and deliver timely assistance.</p>
+          </div>
+        </div>
+
+      </div>
+    </section><!-- End Department Section -->
 
     <!-- ======= Services Section ======= -->
     <section id="services" class="services section-bg">

--- a/inner-page.html
+++ b/inner-page.html
@@ -51,6 +51,7 @@
         <ul>
           <li class="active"><a href="index.html">Home</a></li>
           <li><a href="#about">About</a></li>
+          <li><a href="#department">Department</a></li>
           <li><a href="#services">Services</a></li>
           <li><a href="#portfolio">Portfolio</a></li>
           <li><a href="#team">Team</a></li>

--- a/portfolio-details.html
+++ b/portfolio-details.html
@@ -51,6 +51,7 @@
         <ul>
           <li class="active"><a href="index.html">Home</a></li>
           <li><a href="#about">About</a></li>
+          <li><a href="#department">Department</a></li>
           <li><a href="#services">Services</a></li>
           <li><a href="#portfolio">Portfolio</a></li>
           <li><a href="#team">Team</a></li>


### PR DESCRIPTION
## Summary
- add a Department navigation link across the site header
- introduce a new Department section on the homepage describing key teams

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68c87db5e4548326b68ce99dcf858ce1